### PR TITLE
Fix: cart refreshes accurately for logged-in and non-logged-in users

### DIFF
--- a/client/components/checkout.js
+++ b/client/components/checkout.js
@@ -2,7 +2,7 @@ import React, {Component} from 'react'
 import {connect} from 'react-redux'
 import {Link} from 'react-router-dom'
 import CheckoutForStripe from './stripeCheckout'
-import {updateCart} from '../store/cart'
+import {fetchCart, orderCompleteAndCartReset} from '../store/cart'
 
 class Checkout extends Component {
   constructor(props) {
@@ -25,6 +25,7 @@ class Checkout extends Component {
 
   handleClick() {
     this.props.updateCart(this.state)
+    this.props.fetchCart()
   }
 
   render() {
@@ -215,7 +216,10 @@ const mapStateToProps = state => {
 
 const mapDispatchToProps = dispatch => {
   return {
-    updateCart: formData => dispatch(updateCart(formData))
+    updateCart: formData => dispatch(orderCompleteAndCartReset(formData)),
+    fetchCart() {
+      dispatch(fetchCart())
+    }
   }
 }
 

--- a/client/components/navbar.js
+++ b/client/components/navbar.js
@@ -19,7 +19,7 @@ class Navbar extends Component {
             {this.props.isLoggedIn ? 'My Account' : 'Login / Sign up'}
           </Link>
           <Link to="/cart" id="cart">
-            {this.props.cartQty <= 0 ? 'Cart' : `Cart: ${this.props.cartQty}`}
+            {!this.props.cartQty ? 'Cart' : `Cart: ${this.props.cartQty}`}
           </Link>
         </nav>
       </div>

--- a/client/components/orderSuccess.js
+++ b/client/components/orderSuccess.js
@@ -1,16 +1,34 @@
 import React from 'react'
 import {Link} from 'react-router-dom'
+import {connect} from 'react-redux'
+import {fetchCart} from '../store/cart'
+import {fetchOrders} from '../store/orderHistory'
 
-const OrderSuccess = props => {
-  return (
-    <div className="cartError">
-      <h1>Payment Successful</h1>
-      <div className="error">Thank you for shopping with us!</div>
-      <button className="return" type="button">
-        <Link to="/shop">Browse Products</Link>
-      </button>
-    </div>
-  )
+class OrderSuccess extends React.Component {
+  componentDidMount() {
+    this.props.fetchCart()
+    this.props.fetchOrders()
+  }
+  render() {
+    return (
+      <div className="cartError">
+        <h1>Payment Successful</h1>
+        <div className="error">Thank you for shopping with us!</div>
+        <button className="return" type="button">
+          <Link to="/shop">Browse Products</Link>
+        </button>
+      </div>
+    )
+  }
 }
 
-export default OrderSuccess
+const mapDispatchToProps = dispatch => {
+  return {
+    fetchCart() {
+      dispatch(fetchCart())
+    },
+    fetchOrders: () => dispatch(fetchOrders())
+  }
+}
+
+export default connect(null, mapDispatchToProps)(OrderSuccess)

--- a/client/components/shop.js
+++ b/client/components/shop.js
@@ -3,7 +3,7 @@ import {connect} from 'react-redux'
 import {Link} from 'react-router-dom'
 import {fetchProducts, fetchCategories} from '../store/products'
 
-import {addOrUpdateProduct} from '../store/cart'
+import {addOrUpdateProduct, fetchCart} from '../store/cart'
 
 class Shop extends Component {
   constructor(props) {
@@ -20,6 +20,7 @@ class Shop extends Component {
   componentDidMount() {
     this.props.fetchProducts()
     this.props.fetchCategories()
+    this.props.fetchCart()
   }
 
   handleChange(event) {
@@ -43,9 +44,9 @@ class Shop extends Component {
     event.preventDefault()
     if (event.target.orderQty.value) {
       let productOrderQty = Number(event.target.orderQty.value)
-      let productInCart = this.props.cart.products.find(
-        product => product.id == productId
-      )
+      let productInCart =
+        this.props.cart.products &&
+        this.props.cart.products.find(product => product.id == productId)
       if (productInCart) {
         productOrderQty += productInCart.orderQty.quantity
       }
@@ -150,7 +151,8 @@ const mapDispatchToProps = dispatch => {
     fetchProducts: () => dispatch(fetchProducts()),
     fetchCategories: () => dispatch(fetchCategories()),
     addProduct: (productId, qty, price) =>
-      dispatch(addOrUpdateProduct(productId, qty, price))
+      dispatch(addOrUpdateProduct(productId, qty, price)),
+    fetchCart: () => dispatch(fetchCart())
   }
 }
 

--- a/client/store/cart.js
+++ b/client/store/cart.js
@@ -38,10 +38,10 @@ export const fetchCart = () => async dispatch => {
   }
 }
 
-export const updateCart = formData => async dispatch => {
+export const orderCompleteAndCartReset = formData => async dispatch => {
   try {
-    await axios.put('/api/cart/payment', formData)
-    const action = setCart(defaultCart)
+    const newCart = await axios.put('/api/cart/payment', formData)
+    const action = setCart(newCart)
     dispatch(action)
   } catch (err) {
     console.log(err)


### PR DESCRIPTION
Please review.

todo: when user cancels stripe payment they may end up with 2 or more orders labeled as 'isCart' since this is the moment the db labels the order.isCart property as false (before confirmed checkout)